### PR TITLE
remove superfluous whitespace inside provide forms

### DIFF
--- a/lisp/emacspeak-hide.el
+++ b/lisp/emacspeak-hide.el
@@ -409,7 +409,7 @@ and when you have heard enough navigate easily  to move past the block."
        (t (message "Not on a hidden block"))))))
 
 ;;}}}
-(provide 'emacspeak-hide )
+(provide 'emacspeak-hide)
 ;;{{{ end of file
 
 ;;; local variables:

--- a/lisp/emacspeak-personality.el
+++ b/lisp/emacspeak-personality.el
@@ -456,7 +456,7 @@ Append means place corresponding personality at the end."
                  beg end voice object)))))
 
 ;;}}}
-(provide 'emacspeak-personality )
+(provide 'emacspeak-personality)
 ;;{{{ end of file
 
 ;;; local variables:

--- a/lisp/emacspeak-speak.el
+++ b/lisp/emacspeak-speak.el
@@ -3457,7 +3457,7 @@ This command  is designed for use in a windowing environment like X."
 (define-key minibuffer-local-completion-map "\C-c" 'emacspeak-minibuffer-choose-completion)
 
 ;;}}}
-(provide 'emacspeak-speak )
+(provide 'emacspeak-speak)
 ;;{{{ end of file
 
 ;;; local variables:


### PR DESCRIPTION
Remove the superfluous spaces before the closing parenthesis of a
handful of `provide` forms.  These spaces can mess with tools that
collect provided features using a regexp-base search.

For the Emacsmirror I use such a tool to determine whether the dependencies of all mirrored packages are satisfied and to ensure there are no feature conflicts. By the way I will soon make that data available.