### PR TITLE
Use `mode' instead of `major-mode' for file local variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ install:
 # {{{ end of file
 
 #local variables:
-#major-mode: makefile-mode
+#mode: makefile
 #eval:  (fold-set-marks "# {{{" "# }}}")
 #fill-column: 90
 #folded-file: t

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -59,7 +59,7 @@ pub: tips.html applications.html
 # {{{ end of file 
 
 #local variables: 
-#major-mode: makefile-mode
+#mode: makefile
 #eval:  (fold-set-marks "# {{{" "# }}}")
 #fill-column: 90
 #folded-file: t

--- a/html/releases/release-15.0.html
+++ b/html/releases/release-15.0.html
@@ -299,7 +299,7 @@ Last modified: Mon Nov 19 20:07:23 2001
   </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-16.0.html
+++ b/html/releases/release-16.0.html
@@ -278,7 +278,7 @@ Last modified: Sat May  4 14:29:29 2002
   </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-17.0.html
+++ b/html/releases/release-17.0.html
@@ -274,7 +274,7 @@ Last modified: Mon Nov 18 19:02:15 2002
   </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-18.0.html
+++ b/html/releases/release-18.0.html
@@ -271,7 +271,7 @@ Last modified: Mon Nov 18 19:02:15 2002
   </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-19.0.html
+++ b/html/releases/release-19.0.html
@@ -269,7 +269,7 @@ Emacs.
 </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-20.0.html
+++ b/html/releases/release-20.0.html
@@ -268,7 +268,7 @@ Emacs.
 </body> </html>
 <!--
 local variables:
-major-mode: xml-mode
+mode: xml
 folded-file: t
 end:
 -->

--- a/html/releases/release-21.0.html
+++ b/html/releases/release-21.0.html
@@ -266,7 +266,7 @@ tradition of relying on enhanced productivity to liberate users.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-22.0.html
+++ b/html/releases/release-22.0.html
@@ -267,7 +267,7 @@
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-23.0.html
+++ b/html/releases/release-23.0.html
@@ -269,7 +269,7 @@ fetching full access.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-24.0.html
+++ b/html/releases/release-24.0.html
@@ -277,7 +277,7 @@ pleasurable computing environment for eyes-free interaction.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-25.0.html
+++ b/html/releases/release-25.0.html
@@ -275,7 +275,7 @@
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-26.0.html
+++ b/html/releases/release-26.0.html
@@ -287,7 +287,7 @@ the constraints inherent in traditional adaptive technologies.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-27.0.html
+++ b/html/releases/release-27.0.html
@@ -305,7 +305,7 @@ the constraints inherent in traditional adaptive technologies.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-28.0.html
+++ b/html/releases/release-28.0.html
@@ -325,7 +325,7 @@ the constraints inherent in traditional adaptive technologies.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-29.0.html
+++ b/html/releases/release-29.0.html
@@ -308,7 +308,7 @@ environment for eyes-free interaction.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/html/releases/release-30.0.html
+++ b/html/releases/release-30.0.html
@@ -302,7 +302,7 @@ environment for eyes-free interaction.
   </body> </html>
   <!--
       local variables:
-      major-mode: xml-mode
+      mode: xml
       folded-file: t
       end:
   -->

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -567,7 +567,7 @@ clean:
 # {{{ end of file
 
 #local variables:
-#major-mode: makefile-mode
+#mode: makefile
 #eval:  (fold-set-marks "# {{{" "# }}}")
 #fill-column: 90
 #folded-file: t

--- a/lisp/emacspeak-setup.el
+++ b/lisp/emacspeak-setup.el
@@ -210,7 +210,7 @@ TTS engine should use ALSA for this to be usable."
 ;;{{{  emacs local variables
 
 ;;; local variables:
-;;; major-mode: emacs-lisp-mode
+;;; mode: emacs-lisp
 ;;; folded-file: t
 ;;; end:
 

--- a/lisp/g-client/Makefile
+++ b/lisp/g-client/Makefile
@@ -113,7 +113,7 @@ indent:
 # {{{ end of file
 
 #local variables:
-#major-mode: makefile-mode
+#mode: makefile
 #eval:  (fold-set-marks "# {{{" "# }}}")
 #fill-column: 90
 #folded-file: t

--- a/servers/dtk-exp
+++ b/servers/dtk-exp
@@ -418,7 +418,7 @@ commandloop
 # {{{ Emacs local variables
 
 ### Local variables:
-### major-mode: tcl-mode
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/dtk-lite
+++ b/servers/dtk-lite
@@ -399,7 +399,7 @@ commandloop
 # {{{ Emacs local variables
 
 ### Local variables:
-### major-mode: tcl-mode
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/espeak
+++ b/servers/espeak
@@ -551,7 +551,7 @@ if $mswindows {
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/32-outloud
+++ b/servers/obsolete/32-outloud
@@ -52,7 +52,7 @@ source $wd/outloud
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/32-speech-server
+++ b/servers/obsolete/32-speech-server
@@ -62,7 +62,7 @@ source [lindex $argv 1]
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/dsp-outloud
+++ b/servers/obsolete/dsp-outloud
@@ -302,7 +302,7 @@ commandloop
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/dtk-mv
+++ b/servers/obsolete/dtk-mv
@@ -587,7 +587,7 @@ commandloop
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/dtk-soft
+++ b/servers/obsolete/dtk-soft
@@ -310,7 +310,7 @@ commandloop
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/obsolete/httpd/tts.tcl
+++ b/servers/obsolete/httpd/tts.tcl
@@ -73,7 +73,7 @@ proc ::tts::/say {text} {
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/outloud
+++ b/servers/outloud
@@ -497,7 +497,7 @@ commandloop
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/speech-server
+++ b/servers/speech-server
@@ -62,7 +62,7 @@ source [lindex $argv 1]
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/servers/tts-lib.tcl
+++ b/servers/tts-lib.tcl
@@ -373,7 +373,7 @@ proc tts_initialize {} {
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:

--- a/utils/obsolete/snd-server.tcl
+++ b/utils/obsolete/snd-server.tcl
@@ -145,7 +145,7 @@ set_sound "ding.au"
 # {{{ Emacs local variables  
 
 ### Local variables:
-### major-mode: tcl-mode 
+### mode: tcl
 ### voice-lock-mode: t
 ### folded-file: t
 ### End:


### PR DESCRIPTION
```
As described in `set-auto-mode's docstring, the "mode" file local
variable is treated specially.
```