### PR TITLE
Cleanup of silent formatting in five listed texi source files

### DIFF
--- a/info/binaural.texi
+++ b/info/binaural.texi
@@ -1,72 +1,66 @@
-@subsection Binaural Beats  Using SoX
-A binaural beat is an auditory illusion perceived when two different pure-tone sine waves, both with frequencies lower than 1500 Hz,
-with less than a 40 Hz difference between them, are presented to a listener dichotically (one through each ear). For example, if a 530
-Hz pure tone is presented to a subject's right ear, while a 520 Hz pure tone is presented to the subject's left ear, the listener will perceive
-the auditory illusion of a third tone, in addition to the two pure-tones presented to each ear. The third sound is called a binaural beat, and
-in this example would have a perceived pitch correlating to a frequency of 10 Hz, that being the difference between the 530 Hz and 520
-Hz pure tones presented to each ear.
-For more details,  see @url{https://en.wikipedia.org/wiki/Binaural_beats}.
+@subsection Binaural Beats Using SoX
+
+A binaural beat is an auditory illusion perceived when two different
+pure-tone sine waves, both with frequencies lower than 1500 Hz, with
+less than a 40 Hz difference between them, are presented to a listener
+dichotically (one through each ear).  For example, if a 530 Hz pure
+tone is presented to a subject's right ear, while a 520 Hz pure tone
+is presented to the subject's left ear, the listener will perceive the
+auditory illusion of a third tone, in addition to the two pure-tones
+presented to each ear.  The third sound is called a binaural beat, and
+in this example would have a perceived pitch correlating to a
+frequency of 10 Hz, that being the difference between the 530 Hz and
+520 Hz pure tones presented to each ear.  For more details, see
+@url{https://en.wikipedia.org/wiki/Binaural_beats}.
 
 This module implements a set of user-facing commands for generating
-binaural beats. The commands are organized  
- from high-level commands that present predefined binaural beats to
-lower-level commands that can be used to create new effect sequences.
+binaural beats.  The commands are organized from high-level commands
+that present predefined binaural beats to lower-level commands that
+can be used to create new effect sequences.
 
 @subsubsection High-Level Commands For Pre-Defined Binaural Beats
 
 These commands can be called directly to play one of the predefined
-binaural beats. Each of them prompts for a time-scale factor that is
-used to determine  the duration of the sequence.
+binaural beats.  Each of them prompts for a time-scale factor that is
+used to determine the duration of the sequence.
 
-@itemize
-@item @command{sox-rev-up}: A set of binaural beats designed for  use
-at the start of the day.  Transitions from @emph{Dream} -> @emph{Think}
-->@emph{Act} -> @emph{Focus}.
-@item @command{sox-wind-down}: A  set of binaural beats for winding down
-at the end of  the day.
-This  can be thought of as the reverse of @command{sox-rev-up} and the
-sequence transitions from @emph{Act} -> @emph{Think} -> @emph{Dream} ->@emph{Sleep}.
+@itemize @bullet
+@item @command{sox-rev-up}: A set of binaural beats designed for use
+at the start of the day.  Transitions from @emph{Dream} ->
+@emph{Think} ->@emph{Act} -> @emph{Focus}.
+
+@item @command{sox-wind-down}: A set of binaural beats for winding down
+at the end of the day.  This can be thought of as the reverse of
+@command{sox-rev-up} and the sequence transitions from @emph{Act} ->
+@emph{Think} -> @emph{Dream} ->@emph{Sleep}.
+
 @item @command{sox-turn-down}: Designed for falling asleep.
 This sequence starts with a short period of @emph{Dream} before moving
 to @emph{Sleep}.
-@item @command{sox-relax}:  A variant of the previous sequence,
+
+@item @command{sox-relax}: A variant of the previous sequence,
 @code{sox-relax} spends equal time in @emph{Dream} and @emph{Sleep}.
+
 @item @command{sox-binaural}: Provide a completion-based front-end to
 playing any one of the predefined binaural effects (@emph{Delta},
-@emph{Theta}, @emph{Alpha}, @emph{Beta}, or @emph{Gamma}. The previously
-defined sequences are built up using these effects.
+@emph{Theta}, @emph{Alpha}, @emph{Beta}, or @emph{Gamma}.  The
+previously defined sequences are built up using these effects.
+
 @item @command{sox-beats-binaural}: Plays a collection of binaural
-beats, prompting for fundamental and beat frequencies for each
-tone. The predefined sequences listed earlier were created after first
+beats, prompting for fundamental and beat frequencies for each tone.
+The predefined sequences listed earlier were created after first
 generating experimental beat-sequences using this command.
+
 @item @command{sox-slide-binaural}: Prompts for two binaural effects
-(see above) and generates a binaural beat that
-@emph{slides}  from the first effect to the second over a specified duration.
-@item @command{sox-chakras}: Pick  amongst one of a predefined set of
-sequences designed for  @emph{Chakra} meditation.
+(see above) and generates a binaural beat that @emph{slides} from the
+first effect to the second over a specified duration.
+
+@item @command{sox-chakras}: Pick amongst one of a predefined set of
+sequences designed for @emph{Chakra} meditation.
+
 @item @command{sox-tone-binaural}: Generate a simple binaural beat
 with a single fundamental frequency.
-@item @command{sox-tone-slide-binaural}: Generate a  tone that slides
+
+@item @command{sox-tone-slide-binaural}: Generate a tone that slides
 from one binaural beat to another.
 @end itemize
-
-
-
- sox-wind-down
-                sox-binaural
-                sox-tone-binaural
-                
-                
-                sox-relax
-                
-                sox-tone-slide-binaural
-                
-                
-                
-                
-                sox-beats-binaural
-                sox-slide-binaural
-                sox-chakras
-                sox-rev-up
-                
-                sox-turn-down

--- a/info/documents.texi
+++ b/info/documents.texi
@@ -2,191 +2,178 @@
 
 The Emacspeak environment provides a rich collection of structured
 document authoring tools.  These are well-suited for working in an
-eyes-free environment @MDash{}  you clearly do not want to use a @b{What You See
-Is What You Get} (WYSIWYG) authoring tool if you cannot see what you're
-getting.  Structure-based authoring tools allow you to focus on the act
-of content creation, leaving the minutiae of visual layout to the
-computer.
-
-
+eyes-free environment @MDash{} you clearly do not want to use a
+@b{What You See Is What You Get} (WYSIWYG) authoring tool if you
+cannot see what you're getting.  Structure-based authoring tools allow
+you to focus on the act of content creation, leaving the minutiae of
+visual layout to the computer.
 
 @menu
-* Creating Well-formatted Documents::   Authoring Content.
-* Search replace and spell check::   Fixing errors.
+* Creating Well-formatted Documents:: Authoring Content.
+* Search replace and spell check:: Fixing errors.
 @end menu
 
 @node Creating Well-formatted Documents
 @subsection Creating Well-formatted Documents
-@cindex Document Creation 
+@cindex Document Creation
 
+Before authoring a document, decide its primary audience.  If the
+document contains relatively simple content, e.g., no mathematical
+equations etc. and is primarily targeted at the web, you are probably
+better off using HTML.  You can create well-structured HTML documents
+with the help of package @code{nxml-mode} for editing XML
+documents.  Another option is to use @code{org-mode} to create a
+Wiki-like text document that can be easily published to multiple
+output formats including HTML.
 
-Before authoring a document, decide its primary audience 
-if the document contains relatively simple content e.g., no mathematical
-equations etc. 
-and is primarily targeted at the WWW,  you are probably better off
-using HTML.
-You can create well-structured HTML documents with the help of package 
-@code{nxml-mode}
-for editing  XML documents. Another option is to use @code{org-mode} to create a Wiki-like text document that can be easily published to multiple output formats including HTML.
-
-Packages @code{org-mode} and @code{nxml-mode} are speech-enabled by Emacspeak to
-provide auditory icons, structured navigation and outlines, as well as
-voice locking for audio formatted feedback as you work.
-
+Packages @code{org-mode} and @code{nxml-mode} are speech-enabled by
+Emacspeak to provide auditory icons, structured navigation and
+outlines, as well as voice locking for audio formatted feedback as you
+work.
 
 If the document being authored is more complex, you are usually better
-off creating it in LaTeX.
-Note that LaTeX documents can be converted to HTML either via 
- package @code{tex4ht} @MDash{}  available on the WWW.
+off creating it in @LaTeX{}.  Note that @LaTeX{} documents can be converted
+to HTML either via package @code{tex4ht} @MDash{} available on the
+WWW.
 
-The TeX family of typesetting languages  is suitable for producing 
-well-formatted documents in an eyes-free environment.
-Unlike WYSIWYG environments, 
-the author  of a TeX or LaTeX document works with the content of the
-document, leaving it to the formatting system (TeX) 
-to format the document for good visual presentation.
+The @TeX{} family of typesetting languages is suitable for producing
+well-formatted documents in an eyes-free environment.  Unlike WYSIWYG
+environments, the author of a @TeX{} or @LaTeX{} document works with the
+content of the document, leaving it to the formatting system (@TeX{}) to
+format the document for good visual presentation.
 
-The @code{auctex} package is an Emacs extension that facilitates authoring and
-maintaining structured documents in TeX and LaTeX.  Package
-@code{bibtex} facilitates maintenance and use of @code{bibtex}
-bibliography databases.  The Texinfo package allows creation of software
-documentation that is suitable for both printing as well as online
-viewing as hypertext.  Emacspeak speech-enables packages @code{auctex},
-@code{bibtex} and @code{texinfo} to provide convenient spoken feedback
-as you create  documents. For details on using these
-packages, see their accompanying online info documentation.  
+The @code{AUCTeX} package is an Emacs extension that facilitates
+authoring and maintaining structured documents in @TeX{} and @LaTeX{}.
+Package @code{bibtex} facilitates maintenance and use of @code{bibtex}
+bibliography databases.  The Texinfo package allows creation of
+software documentation that is suitable for both printing as well as
+online viewing as hypertext.  Emacspeak speech-enables packages
+@code{AUCTeX}, @code{bibtex} and @code{texinfo} to provide convenient
+spoken feedback as you create documents.  For details on using these
+packages, see their accompanying online info documentation.
 
 As the document preparation system of choice, Emacspeak supports a
-fluent speech-enabled interface
-to editing and formatting LaTeX documents.
-This interface is provided
-by speech-enabling  @emph{auctex} mode. 
+fluent speech-enabled interface to editing and formatting @LaTeX{}
+documents.  This interface is provided by speech-enabling
+@emph{AUCTeX} mode.
 
-@cindex Auctex 
+@cindex AUCTeX
 
-Mode @emph{auctex} provides efficient keyboard shortcuts for
-inserting and maintaining LaTeX markup as a document is being
-authored.
-All of these editing commands provide succinct auditory
-feedback when used with Emacspeak.
-The syntax coloring provided by this mode is extended to provide @emph{
-  voice locking}
-@MDash{} 
- consequently, Emacspeak uses different voices to speak the
-embedded markup to set it apart from the content.
+Mode @emph{AUCTeX} provides efficient keyboard shortcuts for inserting
+and maintaining @LaTeX{} markup as a document is being authored.  All of
+these editing commands provide succinct auditory feedback when used
+with Emacspeak.  The syntax coloring provided by this mode is extended
+to provide @emph{voice locking} @MDash{} consequently, Emacspeak uses
+different voices to speak the embedded markup to set it apart from the
+content.
 
-Mode @emph{auctex} can be used to create empty document templates and to
-insert document content at the appropriate places in the template.  The
-mode also enables structured navigation of the document as it is being
-edited.  Emacspeak speech-enables these template creation and structured
-navigation commands to produce auditory icons and succinct spoken
-feedback.  For example, while editing, the user can quickly browse
-through the sections of the document and have each section title spoken.
-Document elements such as paragraphs and bulleted lists can be
-manipulated as logical units.  These features are especially relevant in
-an eyes-free environment where the user needs to select logical parts of
-the document without having to point at portions of a visual display.
+Mode @emph{AUCTeX} can be used to create empty document templates and
+to insert document content at the appropriate places in the template.
+The mode also enables structured navigation of the document as it is
+being edited.  Emacspeak speech-enables these template creation and
+structured navigation commands to produce auditory icons and succinct
+spoken feedback.  For example, while editing, the user can quickly
+browse through the sections of the document and have each section
+title spoken.  Document elements such as paragraphs and bulleted lists
+can be manipulated as logical units.  These features are especially
+relevant in an eyes-free environment where the user needs to select
+logical parts of the document without having to point at portions of a
+visual display.
 
 @node Search replace and spell check
 @subsection Searching, Replacing, And Spell Checking
 
 @cindex Search
-@cindex Replace 
+@cindex Replace
 
-Incremental search, a process by which the system prompts the user for a
-search string and moves the selection to the next available match while
-allowing the user to add more characters to the search string, is the
-search technique of choice among most Emacs users.  As the system
-successively finds each match, it provides the user the option of
-continuing the search.  Incremental search is a more complex instance of
-traditional search interaction because in addition to either stopping or
-continuing the search, the user can modify the current search in a
-number of ways including specifying a longer (or shorter)
-search string.
+Incremental search, a process by which the system prompts the user for
+a search string and moves the selection to the next available match
+while allowing the user to add more characters to the search string,
+is the search technique of choice among most Emacs users.  As the
+system successively finds each match, it provides the user the option
+of continuing the search.  Incremental search is a more complex
+instance of traditional search interaction because in addition to
+either stopping or continuing the search, the user can modify the
+current search in a number of ways including specifying a longer (or
+shorter) search string.
 
 All of the user commands available during incremental search are
-documented in the online Emacs info manual.  These are speech-enabled by
-Emacspeak to provide spoken prompts as the dialog begins; auditory
+documented in the online Emacs info manual.  These are speech-enabled
+by Emacspeak to provide spoken prompts as the dialog begins; auditory
 icons indicate a search hit or search miss as the search progresses.
 Along with auditory icons @emph{search-hit} and @emph{search-miss} the
 user also hears the current line spoken, and in the case of a search
 hit, the matching text is @emph{aurally} highlighted by using the
 standard audio formatting technique of changing voice characteristic.
-This feedback proves extremely effective when the search pattern appears
-several times on a single line; the user is unambiguously cued to the
-current match.
-
+This feedback proves extremely effective when the search pattern
+appears several times on a single line; the user is unambiguously cued
+to the current match.
 
 Search and replace actions are an extension to the basic
-conversational gestures of  a search dialog.
-In addition to specifying a search string,
-the user also specifies a replacement string.
-On the Emacspeak desktop, this functionality is provided by
-command @emph{query-replace}.  The
-speech-enabled version of this interaction prompts the user for the
-search and replacement texts.  The 
-auditory feedback during the interactive search and replacement
-process parallels that described in the case of incremental search.
-Audio formatting to indicate the occurrence that is about to be
-replaced proves an effective means of avoiding erroneous modifications
-to the text being edited.  As an example, consider using command @emph{
-  query-replace} to locate and replace the second occurrence of 
-  @b{foo} with @b{bar} in the text
- 
-   @samp{Do not change this fool, but change this food.}
- 
-  
-When the search matches the first occurrence of @b{foo}
- in word @emph{fool}, the aural highlighting helps the user in
- answering ``no'' in response to question ``should this occurrence be
- replaced''.  In addition to allowing the user to supply a
- simple ``yes or no'' answer for each match, command @emph{
-   query-replace} also allows the user to specify a number of other
- valid answers as described  in the online Emacs documentation.
+conversational gestures of a search dialog.  In addition to specifying
+a search string, the user also specifies a replacement string.  On the
+Emacspeak desktop, this functionality is provided by command
+@emph{query-replace}.  The speech-enabled version of this interaction
+prompts the user for the search and replacement texts.  The auditory
+feedback during the interactive search and replacement process
+parallels that described in the case of incremental search.  Audio
+formatting to indicate the occurrence that is about to be replaced
+proves an effective means of avoiding erroneous modifications to the
+text being edited.  As an example, consider using command
+@emph{query-replace} to locate and replace the second occurrence of
+@b{foo} with @b{bar} in the text
 
+@samp{Do not change this fool, but change this food.}
+
+When the search matches the first occurrence of @b{foo} in word
+@emph{fool}, the aural highlighting helps the user in answering ``no''
+in response to question ``should this occurrence be replaced''.  In
+addition to allowing the user to supply a simple ``yes or no'' answer
+for each match, command @emph{query-replace} also allows the user to
+specify a number of other valid answers as described in the online
+Emacs documentation.
 
 @unnumberedsubsubsec Spell Checking
 
-@cindex Spell Check 
+@cindex Spell Check
 
 A more complex instance of conversational gesture ``search and
 replace'' is exhibited by standard spell checking dialogues.  Spell
-checking differs from the search and replace dialog described above
-in that the search and replacement text is guessed by the system based
-on an available dictionary.  Words that are not found in the
-dictionary are flagged as potential spelling errors, and the system
-offers an interactive search and replace dialog for each of these
-possible errors.  During this dialog, the system successively selects
-each occurrence of the possibly erroneous word and offers a set of
-possible replacements.  Unlike in the case of simple search and
-replace, more than one possible replacement string is offered, since a
-potential spelling error can be corrected by more than one word
-appearing in the dictionary.
+checking differs from the search and replace dialog described above in
+that the search and replacement text is guessed by the system based on
+an available dictionary.  Words that are not found in the dictionary
+are flagged as potential spelling errors, and the system offers an
+interactive search and replace dialog for each of these possible
+errors.  During this dialog, the system successively selects each
+occurrence of the possibly erroneous word and offers a set of possible
+replacements.  Unlike in the case of simple search and replace, more
+than one possible replacement string is offered, since a potential
+spelling error can be corrected by more than one word appearing in the
+dictionary.
 
 In the visual interface, such spell checking dialogues are realized by
-displaying the available choices in a pop-up window
-and allowing the user to pick a correction
-Once a correction is selected, the user is offered the choice of
-interactively  replacing the erroneous word with the correction.
+displaying the available choices in a pop-up window and allowing the
+user to pick a correction Once a correction is selected, the user is
+offered the choice of interactively replacing the erroneous word with
+the correction.
 
-The spell checking interface on the Emacspeak desktop is speech-enabled
-to provide fluent auditory feedback.  The visual interface parallels
-that described above and is provided by package @code{ispell} which is
-part of the standard Emacs distribution.  Emacspeak provides a spoken 
-prompt that is composed of the line
-containing the possibly erroneous word (which is aurally highlighted to
-set it apart from the rest of the text on that line) and the available
-corrections.  Each correction is prefixed with a number that the user
-can use to select it.  Once a correction is selected, the interaction
-continues with the query and replace interaction described earlier.  The
-speech interface to the spell checker is as fluent as the visual
-interface.  Notice that Emacspeak users do not need to concern
-themselves with the details of the visual display such as ``the
-corrections are displayed in a window at the top of the screen''.
-
+The spell checking interface on the Emacspeak desktop is
+speech-enabled to provide fluent auditory feedback.  The visual
+interface parallels that described above and is provided by package
+@code{ispell} which is part of the standard Emacs distribution.
+Emacspeak provides a spoken prompt that is composed of the line
+containing the possibly erroneous word (which is aurally highlighted
+to set it apart from the rest of the text on that line) and the
+available corrections.  Each correction is prefixed with a number that
+the user can use to select it.  Once a correction is selected, the
+interaction continues with the query and replace interaction described
+earlier.  The speech interface to the spell checker is as fluent as
+the visual interface.  Notice that Emacspeak users do not need to
+concern themselves with the details of the visual display such as
+``the corrections are displayed in a window at the top of the
+screen''.
 
 In addition to the standard spell checker described above, newer
 versions of Emacs include an ``on-the-fly'' spell checker that flags
-erroneous words as they are typed.
-Emacspeak speech-enables package @code{flyspell} so that such erroneous
-words are aurally highlighted.
+erroneous words as they are typed.  Emacspeak speech-enables package
+@code{flyspell} so that such erroneous words are aurally highlighted.

--- a/info/emacspeak-significance.texi
+++ b/info/emacspeak-significance.texi
@@ -1,16 +1,14 @@
-
 @node Background
 @chapter Background
 
-Emacspeak was originally developed in late 1994 and released as
-Open Source in May 1995.  Since then, the system has been
-regularly updated every six months to provide an up-to-date
-@emph{Audio Desktop}. Here is a brief overview of some of the
-significant aspects of the system, and the lessons learnt from
-its development and use. The work on Emacspeak was presented at
-CHI96 and the co-located Assets96 conference in Vancouver,
-BC. This overview is being written nearly 15 years later to trace
-the impact of the work.
+Emacspeak was originally developed in late 1994 and released as Open
+Source in May 1995.  Since then, the system has been regularly updated
+every six months to provide an up-to-date @emph{Audio Desktop}.  Here
+is a brief overview of some of the significant aspects of the system,
+and the lessons learnt from its development and use.  The work on
+Emacspeak was presented at CHI96 and the co-located Assets96
+conference in Vancouver, BC.  This overview is being written nearly 15
+years later to trace the impact of the work.
 
 @menu
 * Speech-Enabling Applicationss::
@@ -24,76 +22,79 @@ the impact of the work.
 
 The underlying thesis behind AsTeR (Audio System For Technical
 Readings) and later Emacspeak is that information is
-display-independent.  This leads to the insight that  
-producing auditory renderings of information starting from the
-true source of that information often produces better renderings
-than those that result from  working from a modality-specific
-representation; thus, attempting to speak visually rendered
-information can often prove suboptimal. AsTeR  applied these
-ideas to documents authored in @LaTeX{}; Emacspeak generalized these
-ideas to user interfaces.
+display-independent.  This leads to the insight that producing
+auditory renderings of information starting from the true source of
+that information often produces better renderings than those that
+result from working from a modality-specific representation; thus,
+attempting to speak visually rendered information can often prove
+sub-optimal.  AsTeR applied these ideas to documents authored in
+@LaTeX{}; Emacspeak generalized these ideas to user interfaces.
 
 Emacspeak was therefore designed from the ground-up to enable
-applications generate their own spoken feedback, rather than
-having an external software program construct the spoken feedback
-by responding to events in its environment. 
+applications generate their own spoken feedback, rather than having an
+external software program construct the spoken feedback by responding
+to events in its environment.
 
 In Emacspeak, theory meets practice to deliver a working
 implementation; Emacspeak leverages the power of Emacs and its
-embedded Lisp interpreter to inject spoken feedback into
-applications that run within Emacs. For a detailed overview on
-how the  @emph{advice} mechanism in Emacs  is used, see the original
-Assets96 paper, as well as the chapter on Emacspeak in the
-OReilly publication entitled  @url{http://emacspeak.sourceforge.net/raman/publications/bc-emacspeak/publish-emacspeak-bc.html,Beautiful Code}.
+embedded Lisp interpreter to inject spoken feedback into applications
+that run within Emacs.  For a detailed overview on how the
+@emph{advice} mechanism in Emacs is used, see the original Assets96
+paper, as well as the chapter on Emacspeak in the OReilly publication
+entitled
+@url{http://emacspeak.sourceforge.net/raman/publications/bc-emacspeak/publish-emacspeak-bc.html,
+Beautiful Code}.
 
 @node Audio Formatting And Aural CSS
 @section Audio Formatting And Aural CSS
 
-AsTeR introduced the notion of @emph{audio formatting}  a concept
-analogous to the well-understood notion of visual formatting. The
-work on AsTeR coincided with the  Web being at its infancy. As
-the Web evolved to acquire Cascaded Style Sheets (CSS), ideas
-from AsTeR  were used to define Aural CSS as an appendix to CSS1
-in 1995. Emacspeak proved an ideal platform to prototype the
-ideas within Aural CSS @MDash{}  first within the Emacs/W3
-browser. Around this time, Emacs itself evolved to support
-multiple fonts and @emph{font-locking}  to implement syntax coloring
-for various types of content. Emacspeak applied the ideas of
-audio formatting to create the auditory analog of @emph{font-lock}  @MDash
-Emacspeak calls this @emph{voice locking}.
+AsTeR introduced the notion of @emph{audio formatting} a concept
+analogous to the well-understood notion of visual formatting.  The work
+on AsTeR coincided with the Web being at its infancy.  As the Web
+evolved to acquire Cascaded Style Sheets (CSS), ideas from AsTeR were
+used to define Aural CSS as an appendix to CSS1 in 1995.  Emacspeak
+proved an ideal platform to prototype the ideas within Aural CSS
+@MDash{} first within the Emacs/W3 browser.  Around this time, Emacs
+itself evolved to support multiple fonts and @emph{font-locking} to
+implement syntax coloring for various types of content.  Emacspeak
+applied the ideas of audio formatting to create the auditory analog of
+@emph{font-lock} @MDash{} Emacspeak calls this @emph{voice locking}.
 
 Voice locking in Emacspeak continues to be a unique feature among
-systems that provide auditory feedback. Later in 1997,
-Emacspeak's implementation was overhauled to use Aural CSS for
-all aspects of voice-locking, rather than just for Web content.
+systems that provide auditory feedback.  Later in 1997, Emacspeak's
+implementation was overhauled to use Aural CSS for all aspects of
+voice-locking, rather than just for Web content.
 
 @node Auditory Icons
 @section Auditory Icons
 
 Emacspeak augments spoken feedback with short auditory icons that
-vastly speed up interaction. Combined with audio formatting, the
+vastly speed up interaction.  Combined with audio formatting, the
 resulting experience is analogous to moving from a monochrome
-character-cell display to a high-quality color display @MDash{}  the
-overall user experience is rich in comparison. This enabled
-Emacspeak to explore innovative means of auditory communication
-@MDash{}  as an example,  see my Assets-98 paper entitled
-@emph{Conversational Gestures For The Audio Desktop} that details how
-one can play Tetris on the Emacspeak desktop.
+character-cell display to a high-quality color display @MDash{} the
+overall user experience is rich in comparison.  This enabled Emacspeak
+to explore innovative means of auditory communication @MDash{} as an
+example, see my Assets-98 paper entitled @emph{Conversational Gestures
+For The Audio Desktop} that details how one can play Tetris on the
+Emacspeak desktop.
 
 @node Summary
 @section Summary
 
-The lessons learnt from developing Emacspeak are many @MDash{}    here
+The lessons learnt from developing Emacspeak are many @MDash{} here
 are a few highlights:
 
 @itemize
 @item
-A model for browsing tabular data @MDash{}  see relevant chapter in
-my book @emph{Auditory User Interfaces}
+A model for browsing tabular data @MDash{} see relevant chapter in my
+book @emph{Auditory User Interfaces}
+
 @item
 Audio formatting and Aural CSS
+
 @item
 Auditory icons for efficient feedback.
+
 @item
 Web widgets for rapid task completion on the Web.
 @end itemize

--- a/info/emacspeak.texi
+++ b/info/emacspeak.texi
@@ -1,6 +1,6 @@
 \input texinfo
 @c$Id$
-@setfilename./emacspeak.info 
+@setfilename./emacspeak.info
 @include style.texi
 @settitle Emacspeak User's Manual --- 2nd Edition.
 @dircategory Accessibility
@@ -14,26 +14,22 @@
 
 @titlepage
 
-     @title Emacspeak --- The Complete Audio Desktop
+@title Emacspeak --- The Complete Audio Desktop
 @subtitle User Manual
-@author T. V. Raman 
-     Last Updated:  @today{}
-     
-@page
-     @vskip 0pt plus 1filll
-     Copyright @copyright{} 1994--2018 T. V. Raman. All Rights Reserved.
+@author T. V. Raman
+Last Updated: @today{}
 
+@page
+@vskip 0pt plus 1filll
+Copyright @copyright{} 1994--2018 T. V. Raman. All Rights Reserved.
 
 Permission is granted to make and distribute verbatim copies of this
 manual without charge provided the copyright notice and this permission
 notice are preserved on all copies.
 
-
 @summarycontents
 @contents
 @end titlepage
-
-
 
 @include preamble.texi
 @include copyright.texi
@@ -47,13 +43,13 @@ notice are preserved on all copies.
 @include online-help.texi
 @include packages.texi
 @include eterm.texi
-          @include docs.texi
-          @include keyboard.texi
+@include docs.texi
+@include keyboard.texi
 @include tts-server.texi
 @include inc-turning-twenty.texi
 @include acknowledge.texi
 @c trailer
-     
+
 @node Concept Index
 @chapter Concept Index
 @printindex cp
@@ -61,5 +57,5 @@ notice are preserved on all copies.
 @node Key Index
 @chapter Key Index
 @printindex ky
-     
-     @bye
+
+@bye

--- a/info/eterm.texi
+++ b/info/eterm.texi
@@ -1,70 +1,68 @@
 @c $Id$
 
-@node  Running Terminal Based Applications
+@node Running Terminal Based Applications
 @chapter Running Terminal Based Applications.
 
 You can use the terminal emulator mode to run arbitrary terminal-based
 programs from within Emacs.  You open a terminal emulator buffer using
-M-x term, with an extra carriage return to accept the default shell
-(such as bash).  (Incidentally, don't confuse this command with M-x
-terminal-emulator, which starts an older terminal emulator mode not
+@kbd{M-x term}, with an extra carriage return to accept the default shell
+(such as @command{bash}).  (Incidentally, don't confuse this command with @kbd{M-x
+terminal-emulator}, which starts an older terminal emulator mode not
 supported by Emacspeak.)
 
-Three kinds of commands are used within the terminal emulator.
-Normal term commands use a prefix of C-c.  The emacspeak commands for
-eterm mode use a prefix of C-t.  Anything else is a normal shell command.
+Three kinds of commands are used within the terminal emulator.  Normal
+term commands use a prefix of @kbd{C-c}.  The emacspeak commands for
+eterm mode use a prefix of @kbd{C-t}.  Anything else is a normal shell
+command.
 
 There are two sub-modes of term mode: char sub-mode and line sub-mode.
 In char sub-mode, emacspeak will only speak the final chunk of output
-@MDash{}  typically the last line displayed.
-Each character typed (except `term-escape-char`) is sent immediately.
-Use char sub-mode for screen oriented programs like vi or pine.  
+@MDash{} typically the last line displayed.  Each character typed
+(except `term-escape-char`) is sent immediately.  Use char sub-mode
+for screen oriented programs like @command{vi} or @command{pine}.
 
 In line sub-mode, program output is spoken if user option
- @code{eterm-autospeak} is turned on.  When you type a return at the end
- of the buffer, that line is sent as input, while return not at end
- copies the rest of the line to the end and sends it.
-When using terminal line mode with option @code{eterm-autospeak} turned
- on, 
-speech feedback is similar to that obtained in regular @code{shell-mode}
- buffers.
+@code{eterm-autospeak} is turned on.  When you type a return at the
+end of the buffer, that line is sent as input, while return not at end
+copies the rest of the line to the end and sends it.  When using
+terminal line mode with option @code{eterm-autospeak} turned on,
+speech feedback is similar to that obtained in regular
+@code{shell-mode} buffers.
 
-The default is char sub-mode.  You can switch to line sub-mode with C-c
-C-j (recall that control J is a linefeed), and back to char sub-mode
-with C-c C-k (think of character spelled with a K).
+The default is char sub-mode.  You can switch to line sub-mode with
+@kbd{C-c C-j} (recall that control J is a linefeed), and back to char
+sub-mode with @kbd{C-c C-k} (think of character spelled with a K).
 
-Note:  Use char-mode with the terminal emulator for running
-screen-oriented programs like Lynx or Pine.
-For regular shell interaction just use M-x shell 
-instead of using the terminal emulator.
-
-
+Note: Use char-mode with the terminal emulator for running
+screen-oriented programs like Lynx or Pine.  For regular shell
+interaction just use @kbd{M-x shell} instead of using the terminal
+emulator.
 
 @section Char Sub-mode of Term Mode
 
 In char sub-mode of term, each character you type is sent directly to
 the inferior process without intervention from emacs, except for the
-escape character (usually C-c).
+escape character (usually @kbd{C-c}).
 
 Here are some of the useful commands for the char sub-mode.  Note that
 the usual commands for killing a buffer or switching buffers do not work
 in this mode, so new key bindings are supplied.  The first five commands
 are different ways of leaving this mode.
 
-@table @samp
+@table @kbd
 @item C-c C-j
 @kindex C-c C-j
 @itemx M-x term-line-mode
 @findex M-x term-line-mode
-Switch to line sub-mode of term mode.  
+Switch to line sub-mode of term mode.
 
 @item C-c o
 @kindex C-c o
 @itemx M-x other-window
-Select the next window on this frame.
-All windows on current frame are arranged in a cyclic order.
-This command selects the next window in that order.
-If there are no other windows, this command does nothing.
+Select the next window on this frame.  All windows on current frame
+are arranged in a cyclic order.  This command selects the next window
+in that order.  If there are no other windows, this command does
+nothing.
 
 @item C-c C-f
 @kindex C-c C-f
@@ -90,8 +88,8 @@ Offer to save each buffer, then kill this Emacs process.
 @kindex C-c C-d
 @itemx M-x list-directory
 Display a list of files in or matching DIRNAME, a la `ls'.  DIRNAME is
-globbed by the shell if necessary.  Prefix arg (C-u) means supply -l
-switch to `ls'.  The list appears in a second window.
+globbed by the shell if necessary.  Prefix arg (@kbd{C-u}) means supply -l
+switch to @command{ls}.  The list appears in a second window.
 
 @item C-c 1
 @kindex C-c 1
@@ -108,46 +106,44 @@ without any interpretation.
 @item C-c (
 @kindex C-c (
 @itemx M-x start-kbd-macro
-Record subsequent keyboard input, defining a keyboard macro.
-The commands are recorded even as they are executed.
-Use C-c ) to finish recording and make the macro available.
-Use M-x name-last-kbd-macro to give it a permanent name.
-Prefix arg (C-u) means append to last macro defined;
-This begins by re-executing that macro as if you had typed it again.
+Record subsequent keyboard input, defining a keyboard macro.  The
+commands are recorded even as they are executed.  Use @kbd{C-c )} to finish
+recording and make the macro available.  Use @kbd{M-x name-last-kbd-macro}
+to give it a permanent name.  Prefix arg (@kbd{C-u}) means append to last
+macro defined; This begins by re-executing that macro as if you had
+typed it again.
 
 @item C-c )
 @kindex C-c )
 @itemx M-x end-kbd-macro
-Finish defining a keyboard macro.
-The definition was started by C-c (.
-The macro is now available for use via C-c e,
-or it can be given a name with M-x name-last-kbd-macro and then invoked
-under that name.
+Finish defining a keyboard macro.  The definition was started by
+@kbd{C-c (}.  The macro is now available for use via @kbd{C-c e}, or
+it can be given a name with @kbd{M-x name-last-kbd-macro} and then
+invoked under that name.
 
 @item C-c e
 @kindex C-c e
 @itemx M-x call-last-kbd-macro
-Call the last keyboard macro that you defined with C-c (.
-A prefix argument serves as a repeat count.  Zero means repeat until
+Call the last keyboard macro that you defined with @kbd{C-c (}.  A
+prefix argument serves as a repeat count.  Zero means repeat until
 error.
 @end table
 
 You can get a list of all the key sequences with a C-c prefix by typing
-C-c C-h while in this sub-mode.  Some of those commands are only available
+@kbd{C-c C-h} while in this sub-mode.  Some of those commands are only available
 in the char sub-mode, while others are generally available.
-
 
 @section Line Sub-mode of Term Mode
 
 In line sub-mode of term mode, emacs editing commands work normally,
-until you type RET which sends the current line to the inferior process.
+until you type @key{RETURN} which sends the current line to the inferior process.
 
 Here are some of the useful commands for the line sub-mode of the term
 mode.  In addition, the usual commands for handling a buffer work in
-this mode (C-x o to switch windows, C-x k to kill a buffer, C-x f to
-find a file, and so forth).
+this mode (@kbd{C-x o} to switch windows, @kbd{C-x k} to kill a
+buffer, @kbd{C-x f} to find a file, and so forth).
 
-@table @samp
+@table @kbd
 @item C-c C-k
 @kindex C-c C-k
 @itemx M-x term-char-mode
@@ -157,11 +153,12 @@ Switch to char sub-mode of term mode.
 @kindex C-c C-z
 @itemx M-x term-stop-subjob
 Stop the current subjob.  Resume the subjob in the foreground with the
-ordinary command fg, or run it in the background with bg.  WARNING: if
-there is no current subjob, you can end up suspending the top-level
-process running in the buffer. If you accidentally do this, use M-x
-term-continue-subjob to resume the process. (This is not a problem with
-with most shells, including bash, since they ignore this signal.)
+ordinary command @command{fg}, or run it in the background with
+@command{bg}.  WARNING: if there is no current subjob, you can end up
+suspending the top-level process running in the buffer.  If you
+accidentally do this, use @kbd{M-x term-continue-subjob} to resume the
+process.  (This is not a problem with most shells, including
+@command{bash}, since they ignore this signal.)
 
 @item C-c C-\
 @kindex C-c C-\
@@ -187,8 +184,8 @@ Kill all text from last stuff output by interpreter to point.
 @kindex C-c C-a
 @itemx M-x term-bol
 Goes to the beginning of line, then skips past the prompt, if any.
-If a prefix argument is given (C-u), then no prompt skip
-@MDash{}  go straight to column 0.
+If a prefix argument is given (@kbd{C-u}), then no prompt skip
+@MDash{} go straight to column 0.
 
 @item C-c C-d
 @kindex C-c C-d
@@ -196,39 +193,38 @@ If a prefix argument is given (C-u), then no prompt skip
 Send an end of file character (EOF) to the current buffer's process.
 @end table
 
-You can get a list of all the key sequences with a C-c prefix by typing
-C-c C-h while in this sub-mode.  Some of those commands are only available
-in the line sub-mode, while others are generally available.
-
-
-
+You can get a list of all the key sequences with a @kbd{C-c} prefix by
+typing @kbd{C-c C-h} while in this sub-mode.  Some of those commands
+are only available in the line sub-mode, while others are generally
+available.
 
 @section Eterm Mode Commands
 
-The eterm mode maintains a pointer, which is not necessarily the same as
-the terminal's cursor.  It is intended to be used in eterm's char
-submode.  In char submode, C-t , (that's control-t followed by comma)
-will tell you where the eterm pointer is.  C-t C-i will tell you where
-the terminal's cursor is.  The top left corner of the window is "row 0
-column 0".
+The eterm mode maintains a pointer, which is not necessarily the same
+as the terminal's cursor.  It is intended to be used in eterm's char
+submode.  In char submode, @kbd{C-t ,} (that's control-t followed by
+comma) will tell you where the eterm pointer is.  @kbd{C-t C-i} will
+tell you where the terminal's cursor is.  The top left corner of the
+window is "row 0 column 0".
 
-The eterm pointer can be moved with C-t < (to the top of the screen),
-C-t > (to the bottom of the screen), C-t n (to the next line), C-t p (to
-the previous line), and C-t . (to the cursor).  Each of these also
-speaks the line the pointer moves to.  You can also search forward with
-C-t s.  
-@c , or search backward with C-t r.
+The eterm pointer can be moved with @kbd{C-t <} (to the top of the
+screen), @kbd{C-t >} (to the bottom of the screen), @kbd{C-t n} (to
+the next line), @kbd{C-t p} (to the previous line), and @kbd{C-t .}
+(to the cursor).  Each of these also speaks the line the pointer moves
+to.  You can also search forward with @kbd{C-t s}.
+@c , or search backward with @kbd{C-t r}.
 
-These commands speak without moving the pointer: C-t l (current line),
-C-t w (current word), C-t c (current character), and C-t [space] (from
-eterm pointer to cursor).
+These commands speak without moving the pointer: @kbd{C-t l} (current
+line), @kbd{C-t w} (current word), @kbd{C-t c} (current character),
+and @kbd{C-t @key{SPACE}} (from eterm pointer to cursor).
 
-You may enter review mode with C-t q.  In review mode, you can search
-the buffer and speak its contents, without disturbing the terminal.
-Commands for moving the pointer are similar to normal editing commands,
-but without a control key: n and p for next and previous line, f and b
-for forward and back by characters, < and > for the beginning or end of
-the buffer.  c, w, and l speak the current character, word, and line.  s
-searches forward (not incrementally).  A comma speaks the pointer
-location.  A period moves the pointer to the terminal cursor.  Return to
-normal term mode by typing q.
+You may enter review mode with @kbd{C-t q}.  In review mode, you can
+search the buffer and speak its contents, without disturbing the
+terminal.  Commands for moving the pointer are similar to normal
+editing commands, but without a control key: @kbd{n} and @kbd{p} for
+next and previous line, @kbd{f} and @kbd{b} for forward and back by
+characters, @kbd{<} and @kbd{>} for the beginning or end of the
+buffer.  @kbd{c}, @kbd{w}, and @kbd{l} speak the current character,
+word, and line.  @kbd{s} searches forward (not incrementally).  A
+comma speaks the pointer location.  A period moves the pointer to the
+terminal cursor.  Return to normal term mode by typing @kbd{q}.


### PR DESCRIPTION
Mr. Raman,

This single commit on my 'texi' branch contains a Sunday evening's work tidying up formatting in the first few texi files that I encountered. (I skipped a large one that appeared to be generated from code.) I expect that many of my changes are silent and therefore of little worth to your audience but I hope that indicating the keyboard, key and command markup are audible in the info reader. The PDF is a little prettier for it anyway. Please review and comment before I invest more time in this direction. Thank you. -- Daniel Birket

Modified texi files:
binaural, documents, emacspeak-significance, emacspeak, eterm

Cleanup of:
- irregular whitespace (leading, trailing, unnecessary)
- use of period double-space sentence breaks
- Capitalization
- @TeX{} and @LaTeX{} macros
- @kbd{}, @command{}, @key{} content-indicating macros
- text width (used M-q)

These changes produced few real diffs in the .info output.
Quotes appear around the eterm keyboard commands. The PDF output of
the eterm section is improved by using @kbd{} inline and as a format
for @itemize.