### PR TITLE
PDF Title Page and Table of Contents format fix.

### DIFF
--- a/info/emacspeak.texi
+++ b/info/emacspeak.texi
@@ -12,10 +12,10 @@
 @direntry
 * Emacspeak:(emacspeak).		Speech-enabled Audio Desktop.
 @end direntry
-@raggedright 
+
 @titlepage
 
-@title Emacspeak --- The Complete Audio Desktop
+@title Emacspeak@*The Complete Audio Desktop
 @subtitle User Manual
 @author T. V. Raman
 Last Updated: @today{}
@@ -28,11 +28,11 @@ Permission is granted to make and distribute verbatim copies of this
 manual without charge provided the copyright notice and this permission
 notice are preserved on all copies.
 
+@end titlepage
+
 @summarycontents
 @contents
 
-@end titlepage
-@end raggedright 
 @include preamble.texi
 @include copyright.texi
 @include announce.texi


### PR DESCRIPTION
Mr. Raman,

Please accept this pull request to address the bounding-box errors in the table of contents of the PDF version of the manual. These were resolved by moving the summary contents and contents commands after the end title page command as described in the texinfo manual. This produces a title page, a copyright page, then a summary contents pages and then many contents pages.

The contents pages previously suffered from a layout issue that caused the page numbers to not align in a vertical column where the section heading text was longer than average. This has been corrected. I removed your experimental ragged right commands as they were unnecessary and inappropriate there.

I also replaced the M-dash in the title line "Emacspeak M-dash The Complete Audio Desktop" with a line-break command, at-asterisk. This places "Emacspeak" and "The Complete Audio Desktop" on separate lines in the same large font above the title horizontal rule without awkwardly breaking "The Complete Audio Desktop" across these lines. This has no apparent effect on the info or html versions of the manual, only the PDF title page.

Two other items, please, while I have your attention:

There has been no response to my attempts to join the emacspeak mailing list. The instructions for this are quite terse. Do you have any advice?

It appears that the workflow that you are using to process these pull requests is outside the collaboration mechanisms provided by GitHub. I imagine that this is for good reason, probably related to the accessibility of GitHub. Please know that GitHub would normally record and display contributions via pull-requests like this one and that the method that you are using does not. All changes, including my two previous pull requests for example, are credited to you. This pattern is perhaps what gave me the impression that emacspeak is a closely-held one-man show and not open to collaborators. Please consider the damping effect that denying contributors visible credit may be having on contributions to your project.

Daniel Birket

Commit Comment:

Removed experimental @raggedright from around @titlepage block.
Moved @summarycontents and @contents after @end titlepage as
described in the texinfo manual under "Generating a Table of Contents".
This permits normal TOC layout and eliminates many bounding-box errors.