### PR TITLE
Loads SRE via MathJax.

### DIFF
--- a/js/node/math-server.js
+++ b/js/node/math-server.js
@@ -39,11 +39,12 @@ let net = require('net');
 
 // Initialize Math rendering system.
 
-let mjx = require('mathjax');
-let promise = mjx.init({loader: {load: ['input/tex']}});
+let mjx = require('mathjax-full');
+let promise = mjx.init(
+  {loader: {paths: {sre: 'mathjax-full/js/a11y/sre-node'},
+            load: ['input/tex-full', 'a11y/semantic-enrich']}});
 
 // Speech Rules Engine.
-let sre = require('speech-rule-engine');
 sre.setupEngine(
     {markup: 'acss', domain: 'emacspeak', rules: ['EmacspeakRules']});
 

--- a/js/node/math-server.js
+++ b/js/node/math-server.js
@@ -42,7 +42,7 @@ let net = require('net');
 let mjx = require('mathjax-full');
 let promise = mjx.init(
   {loader: {paths: {sre: 'mathjax-full/js/a11y/sre-node'},
-            load: ['input/tex-full', 'a11y/semantic-enrich']}});
+            load: ['input/tex-full', 'output/svg', 'a11y/semantic-enrich']}});
 
 // Speech Rules Engine.
 sre.setupEngine(

--- a/js/node/package-lock.json
+++ b/js/node/package-lock.json
@@ -9,10 +9,25 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
             "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         },
-        "mathjax": {
+        "esm": {
+            "version": "3.2.25",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+        },
+        "mathjax-full": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.0.5.tgz",
-            "integrity": "sha512-9M7VulhltkD8sIebWutK/VfAD+m+6BIFqfpjDh9Pz/etoKUtjO6UMnOhUcDmNl6iApE8C9xrUmaMyNZkZAlrMw=="
+            "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.0.5.tgz",
+            "integrity": "sha512-RzZ03DDMOgqeHPl3dkqDVS3bmXU+lfZZimj7+k3VA+s93LbZcOAKa2hlILF3rgBXgzGLR3YOR8Z8R/B3uAeAeA==",
+            "requires": {
+                "esm": "^3.2.25",
+                "mj-context-menu": "^0.2.2",
+                "speech-rule-engine": "^3.0.0-beta.10"
+            }
+        },
+        "mj-context-menu": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.2.tgz",
+            "integrity": "sha512-OHlnKQqfFPEYZGdz2JWL0obrr82vVilha0WCUZslYfN+v+oz4VpmERnoHdTUWvOUVHNYjFkpOYnLEeHnt1BdsQ=="
         },
         "net": {
             "version": "1.0.2",

--- a/js/node/package.json
+++ b/js/node/package.json
@@ -23,8 +23,7 @@
     },
     "homepage": "https://github.com/tvraman/emacspeak",
     "dependencies": {
-        "mathjax": ">= 3.0.0",
-        "net": ">=1.0.2",
-        "speech-rule-engine": "^3.0.0-beta.11"
+        "mathjax-full": ">= 3.0.0",
+        "net": ">=1.0.2"
     }
 }

--- a/lisp/emacspeak-maths.el
+++ b/lisp/emacspeak-maths.el
@@ -338,7 +338,7 @@ left for next run."
   (let ((server
          (make-comint
           "Server-Maths" emacspeak-maths-inferior-program nil
-          emacspeak-maths-server-program))
+          "-r" "esm" emacspeak-maths-server-program))
         (client nil))
     (accept-process-output (get-buffer-process server) 1.0 nil 'just-this-one)
     (setq client


### PR DESCRIPTION
This integrates SRE via MathJax directly. Changes are:
* Requires `mathjax-full` instead of `mathjax` package.
* Starts node with the `esm` flag to enable ES6 modules.
* Loads `tex-full` to have all packages available.

There is no more need to install or require `speech-rule-engine` explicitly. On the other hand it loads some MathJax components that are not necessarily useful and makes `node_module` larger.

Have a look if you prefer that.