### PR TITLE
Remove capitalization controls from espeak server

### DIFF
--- a/servers/espeak
+++ b/servers/espeak
@@ -297,23 +297,12 @@ proc sh  {{duration 50}} {
     return ""
 }
 
-# Caps: this driver currently offers either
-# - announcing each capitals (tts_split_caps)
-# - or raising pitch (tts_capitalize)
-# - or beeping (tts_allcaps_beep)
-#
 proc tts_split_caps {flag} {
-    global tts 
-    if { $flag == 1 } {
-	caps "spelling"
-    } else {
-	if {$tts(capitalize) == 0    } {
-	    caps "none"
-	}
-    }
-    service
+    global tts
+    set tts(split_caps) $flag
     return ""
 }
+
 proc tts_reset {} {
     global tts
     #synth  -reset


### PR DESCRIPTION
Announcing capitals is now solely controlled by emacspeak and the
espeak synthesizer's insertion of the string "Capitalize" (or a beep
or pitch change, though there is no longer a user interface for
enabling this) caused redundant announcements with `dtk-split-caps`.

(Note that since this is branched off of `master` and not #59 , the warnings mentioned in #59 are still present here, though if ;#59 lands first I can merge it in to get rid of them)