### PR TITLE
MacOS: Fix execution of espeak-server.

### DIFF
--- a/servers/espeak
+++ b/servers/espeak
@@ -5,7 +5,7 @@
 # LCD Archive Entry:
 # emacspeak| T. V. Raman |raman@cs.cornell.edu
 # A speech interface to Emacs |
-# $Date: 2006-08-11 21:11:17 +0200 (ven, 11 aoû 2006) $ |
+# $Date: 2006-08-11 21:11:17 +0200 (ven, 11 aoÃ» 2006) $ |
 #  $Revision: 4047 $ | 
 # Location undetermined
 #
@@ -485,7 +485,7 @@ set tts(input) stdin
 if {[info exists server_p]} {
     set tts(input) sock0
 }
-set servers [file dirname $argv0]
+set servers [file normalize [file dirname $argv0]]
 set tclTTS $servers/native-espeak
 load $tclTTS/tclespeak[info sharedlibextension]
 if {[file exists /proc/asound]} {


### PR DESCRIPTION
Without this change, the espeak-server throws this error message:

> dlopen(./native-espeak/tclespeak.dylib, 0x000A): tried: './native-espeak/tclespeak.dylib' (relative path not allowed in hardened program), '/usr/lib/tclespeak.dylib' (no such file)
>     while executing
> "load $tclTTS/tclespeak[info sharedlibextension]"
>     (file "./espeak" line 490)

I just used the "file normalize" function to get an absolute path.
Now everything works as expected, tested with MacOS Monterey on Apple M1.