### PR TITLE
fix deprecation warning for sink_master

### DIFF
--- a/etc/pulse/default.pa
+++ b/etc/pulse/default.pa
@@ -7,7 +7,7 @@ flat-volumes = no
 
 # A bs2b (binaural for headphones) sink:
 
-load-module module-ladspa-sink sink_name=binaural  master=@DEFAULT_SINK@ plugin=bs2b label=bs2b control=725,6.5
+load-module module-ladspa-sink sink_name=binaural sink_master=@DEFAULT_SINK@ plugin=bs2b label=bs2b control=725,6.5
 
 # Use binaural as the default sink:
 #set-default-sink  binaural 


### PR DESCRIPTION
A simple 5 character fix for the following PulseAudio warning:

```
The 'master' module argument is deprecated and may be removed in the future, please use the 'sink_master' argument instead.
```