### PR TITLE
Minimal upgrade of servers/mac to python3

### DIFF
--- a/servers/mac
+++ b/servers/mac
@@ -224,7 +224,7 @@ def gotLine(observer, aLine):
     AppHelper.stopEventLoop()
 
 def gotError(observer, err):
-  print("error:", err)
+  print(("error:", err))
   AppHelper.stopEventLoop()
 
 def writeDebugLog(level, output):
@@ -237,7 +237,7 @@ def writeDebugLog(level, output):
       DEBUGFILE.write("\n" + output)
       # Write debug messages to STDOUT if requested as well
       if debugToSTDOUT:
-        print(output + "\n")
+        print((output + "\n"))
     DEBUGFILE.flush()
 
 

--- a/servers/mac
+++ b/servers/mac
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # E-Mac-Speak
 # Emacspeak on Mac.
 


### PR DESCRIPTION
This will close #68 (technically already closed by an April fix), and ensures the server/mac plays nice with python3.  This has been tested on m1 and intel macs with OS 12.x and 13.x. 