### PR TITLE
Update vertico to match other completion frameworks's announcements

### DIFF
--- a/lisp/emacspeak-vertico.el
+++ b/lisp/emacspeak-vertico.el
@@ -89,16 +89,13 @@
                       0)))
         (to-speak nil))
     (unless (equal emacspeak-vertico--prev-candidate new-cand)
-      (push new-cand to-speak)
+      (setq to-speak new-cand)
       (when (or (equal vertico--index emacspeak-vertico--prev-index)
                 (and (not (equal vertico--index -1))
                      (equal emacspeak-vertico--prev-index -1)))
-        (push "candidate" to-speak)))
-    (when (and (not vertico--allow-prompt)
-               (equal emacspeak-vertico--prev-candidate nil))
-      (push "first candidate" to-speak))
+        (emacspeak-auditory-icon 'select-object)))
     (when to-speak
-      (dtk-speak (mapconcat 'identity to-speak " ")))
+      (dtk-speak to-speak))
     (setq-local
      emacspeak-vertico--prev-candidate new-cand
      emacspeak-vertico--prev-index vertico--index)))


### PR DESCRIPTION
Change vertico's advice to play the select-object icon when the completion you'd get when pressing enter changes. This makes the vertico support more consistent with other completenon modes like ivy or selectrum.

This change is prompted by user feedback I encountered at https://tweesecake.social/@devinprater/111018379856922802