### PR TITLE
A grammar fix and mention docs contributions are accepted on Github

### DIFF
--- a/info/announce.texi
+++ b/info/announce.texi
@@ -18,8 +18,10 @@ provides a complete audio desktop.
 
 This manual is organized as a series of chapters, with each chapter in
 a separate file.  If you feel capable of contributing to a specific
-section, send out a message to the Emacspeak mailing list
-@url{mailto:emacspeak@@cs.vassar.edu}.  You can then start adding
+section, send out a message to the
+@url{mailto:emacspeak@@cs.vassar.edu, Emacspeak mailing list} or a
+@url{https://github.com/tvraman/emacspeak/pulls, pull-request},
+whichever you feel more comfortable with.  You can then start adding
 content to a local copy of the chapter to which you are contributing.
 When you feel you have something to submit, mail out the file to the
 emacspeak mailing list @MDash{} I'll integrate new content as it comes

--- a/info/docs.texi
+++ b/info/docs.texi
@@ -12424,7 +12424,7 @@ Speak completions if available.
 @format
 Speak a buffer continuously.
 First prompts using the minibuffer for the kind of action to
-perform after speaking each chunk.  E.G.  speak a line at a time
+perform after speaking each chunk.  E.g.  speak a line at a time
 etc.  Speaking commences at current buffer position.  Pressing
 C-g breaks out, leaving point on last chunk that
 was spoken.  Any other key continues to speak the buffer.

--- a/info/emacspeak.info-1
+++ b/info/emacspeak.info-1
@@ -88,10 +88,12 @@ File: emacspeak.info,  Node: Contributing,  Next: Authoring Guidelines,  Up: Ann
 This manual is organized as a series of chapters, with each chapter in a
 separate file.  If you feel capable of contributing to a specific
 section, send out a message to the Emacspeak mailing list
-<mailto:emacspeak@cs.vassar.edu>.  You can then start adding content to
-a local copy of the chapter to which you are contributing.  When you
-feel you have something to submit, mail out the file to the emacspeak
-mailing list — I’ll integrate new content as it comes in.
+(mailto:emacspeak@cs.vassar.edu) or a pull-request
+(https://github.com/tvraman/emacspeak/pulls), whichever you feel more
+comfortable with.  You can then start adding content to a local copy of
+the chapter to which you are contributing.  When you feel you have
+something to submit, mail out the file to the emacspeak mailing list —
+I’ll integrate new content as it comes in.
 
 
 File: emacspeak.info,  Node: Authoring Guidelines,  Next: Credits,  Prev: Contributing,  Up: Announce

--- a/info/emacspeak.info-1
+++ b/info/emacspeak.info-1
@@ -499,7 +499,7 @@ distinctions captured by the HTML markup to be communicated efficiently
 *Note Web Browsing::.
 
    It is often desirable to exercise control over the pronunciation of a
-word (E.G. a technical term or a reserved word in a programming
+word (e.g. a technical term or a reserved word in a programming
 language) within specific contexts.  Emacspeak maintains pronunciation
 dictionaries for this purpose, which may be customized by the user.
 Moreover, individual dictionaries can be activated selectively,

--- a/info/emacspeak.info-2
+++ b/info/emacspeak.info-2
@@ -4744,7 +4744,7 @@ of emacspeak from becoming dependent on the speech server modules
 
      Speak a buffer continuously.
      First prompts using the minibuffer for the kind of action to
-     perform after speaking each chunk.  E.G.  speak a line at a time
+     perform after speaking each chunk.  E.g.  speak a line at a time
      etc.  Speaking commences at current buffer position.  Pressing
      C-g breaks out, leaving point on last chunk that
      was spoken.  Any other key continues to speak the buffer.

--- a/info/using.texi
+++ b/info/using.texi
@@ -53,7 +53,7 @@ structural distinctions captured by the HTML markup to be communicated
 efficiently @xref{Web Browsing}.
 
 It is often desirable to exercise control over the pronunciation of a
-word (E.G. a technical term or a reserved word in a programming
+word (e.g. a technical term or a reserved word in a programming
 language) within specific contexts. Emacspeak maintains pronunciation
 dictionaries for this purpose, which may be customized by the
 user. Moreover, individual dictionaries can be activated selectively,

--- a/lisp/emacspeak-speak.el
+++ b/lisp/emacspeak-speak.el
@@ -1960,7 +1960,7 @@ location of the mark is indicated by an aural highlight. "
 (defun emacspeak-speak-continuously ()
   "Speak a buffer continuously.
 First prompts using the minibuffer for the kind of action to
-perform after speaking each chunk.  E.G.  speak a line at a time
+perform after speaking each chunk.  E.g.  speak a line at a time
 etc.  Speaking commences at current buffer position.  Pressing
 \\[keyboard-quit] breaks out, leaving point on last chunk that
 was spoken.  Any other key continues to speak the buffer."

--- a/servers/native-espeak/tclespeak.cpp
+++ b/servers/native-espeak/tclespeak.cpp
@@ -449,7 +449,7 @@ static int initLanguage(Tcl_Interp *interp) {
   if (remove != string::npos) {
     aDefaultLang.erase(aDefaultLang.begin() + remove, aDefaultLang.end());
   }
-  // And replace _ with -, E.G. en_US becomes en-US.
+  // And replace _ with -, e.g. en_US becomes en-US.
   for (string::iterator it = aDefaultLang.begin(); it != aDefaultLang.end();
        it++) {
     if (*it == '_') {


### PR DESCRIPTION
1st commit fixes `e.g.` being capitalized in various places.

2nd commit adds mentioning that contributions are accepted on Github, as per https://github.com/tvraman/emacspeak/issues/94