### PR TITLE
run: don't open a non-existing $& file

### DIFF
--- a/run
+++ b/run
@@ -4,5 +4,4 @@
 #
 :${DTK_PROGRAM} ? "Using ${DTK_PROGRAM}" : export DTK_PROGRAM="espeak"
 export EMACSPEAK_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-emacs "$&"
-
+emacs


### PR DESCRIPTION
It's not clear what this "$&" was for, but it results in Emacs starting via `./run` script opening the $& buffer, which is not useful. So fix that.

------------

@tvraman  please, can you not remove my authorship from the commits, I'd prefer them to show up on my profile.