### PR TITLE
Evil-mode improvement: read in visual lines when moving in visual lines

### DIFF
--- a/lisp/emacspeak-evil.el
+++ b/lisp/emacspeak-evil.el
@@ -93,15 +93,24 @@
 ;; auditory icons when they execute
 (cl-loop
  for f in
- '(
-   evil-next-line evil-previous-line
-   evil-next-visual-line evil-previous-visual-line)
+ '(evil-next-line evil-previous-line)
  do
  (eval
   `(defadvice ,f (after emacspeak pre act comp)
      "speak."
      (when (ems-interactive-p)
        (emacspeak-speak-line)))))
+
+;; read visual lines when moving in visual lines 
+(cl-loop
+ for f in
+ '(evil-next-visual-line evil-previous-visual-line)
+ do
+ (eval
+  `(defadvice ,f (after emacspeak pre act comp)
+     "speak."
+     (when (ems-interactive-p)
+       (emacspeak-speak-visual-line)))))
 
 (cl-loop
  for f in


### PR DESCRIPTION
Evil mode has the idea of moving in visual lines even when not in visual-line-mode, this patch makes it read visual lines rather than entire lines when you move specifically with these commands. 

Instead of hitting j to go down a line, you hit "gj" to move down a visual line and this makes it work properly with emacspeak. 