### PR TITLE
Fix broken emacspeak when missing sox

### DIFF
--- a/lisp/emacspeak-sounds.el
+++ b/lisp/emacspeak-sounds.el
@@ -110,12 +110,14 @@ Use Serve when working with remote speech servers.")
 ;;;###autoload
 (defun emacspeak-auditory-icon (icon)
   "Play an auditory ICON."
-  (cl-declare (special emacspeak-use-auditory-icons emacspeak-play-program ))
+  (cl-declare (special emacspeak-use-auditory-icons emacspeak-play-program))
   (when emacspeak-use-auditory-icons
-    (unless emacspeak-play-program
-      (setq-default emacspeak-use-auditory-icons nil)
-      (error "No valid player for auditory icons."))
-    (funcall emacspeak-auditory-icon-function icon)))
+    (if emacspeak-play-program
+        (funcall emacspeak-auditory-icon-function icon)
+      (progn
+        (message (concat "No valid player for auditory icons. "
+                         "Setting emacspeak-use-auditory-icons to nil"))
+        (setq-default emacspeak-use-auditory-icons nil)))))
 
 ;;; Sounds Cache:
 


### PR DESCRIPTION
There might be a better way to fix this, but here is my attempt.

Behavior: When missing sox on MacOS, Emacspeak wouldn't entirely crash but would go into a very odd mode of working.  Moving lines and lots of other things would generate no messages, and this was confirmed by using log-swiftmac to see that messages were not being sent when switching lines.  Typing keys still worked and echoed.

Discovery: So, I did some bisecting and I found the problem was in the commit 11121766c. When trying to fix it, it appears to me it had two problems. The first is even when the unless code was run, it would still at least once try to execute the binary which does not exist. The second and more confusing problem is that when you run (error "some message") it triggers the breakage, and I can not understand why that creates this unique broken condition. I tried adding (interactive) to the function, it didn't change the behavior.

Solution: This patch still emits a message telling the user what is going on but everything continues to function properly and it never runs the path that attempts to use sox.