### PR TITLE
SwiftMac 2.7.5: swift 5.9 concurrency update + no more warnings

### DIFF
--- a/servers/mac-swiftmac/.gitignore
+++ b/servers/mac-swiftmac/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 universal/
+Package.resolved

--- a/servers/mac-swiftmac/Package.swift
+++ b/servers/mac-swiftmac/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift
 // required to build this package.
 
@@ -20,7 +20,8 @@ let package = Package(
     // Dependencies declare other packages that this package
     // depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/arkasas/OggDecoder.git", .branch("main"))
+    // .package(url: "https://github.com/robertmeta/OggDecoder.git", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/robertmeta/OggDecoder.git", branch: "main")
   ],
   targets: [
     // Targets are the basic building blocks of a package.
@@ -33,7 +34,11 @@ let package = Package(
       path: "Sources/SwiftMacPackage",
       sources: [
         "logger.swift", "statestore.swift", "soundmanager.swift", "toneplayer.swift", "main.swift",
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-suppress-warnings"])
       ]
+
     )
   ]
 )

--- a/servers/mac-swiftmac/Readme.org
+++ b/servers/mac-swiftmac/Readme.org
@@ -1,6 +1,7 @@
-* swiftmac
+* SwiftMac
+
 This is a server for Emacspeak for modern macs using
-swift 5.5+.
+swift 5.9+.
 
 Project: https://github.com/robertmeta/swiftmac
 

--- a/servers/mac-swiftmac/Sources/SwiftMacPackage/logger.swift
+++ b/servers/mac-swiftmac/Sources/SwiftMacPackage/logger.swift
@@ -30,7 +30,9 @@ class Logger {
     }
 
     func log(_ m: String) {
-      let message = m + "\n"
+      // let message = m + "\n"
+      let ts = ""
+      let message = ts + m + "\n"
       backgroundQueue.async { [weak self] in
         guard let self = self else { return }
 

--- a/servers/mac-swiftmac/Sources/SwiftMacPackage/main.swift
+++ b/servers/mac-swiftmac/Sources/SwiftMacPackage/main.swift
@@ -15,7 +15,7 @@ import OggDecoder
 #else
   let debugLogger = Logger()  // No-Op
 #endif
-let version = "2.7"
+let version = "2.7.5"
 let name = "swiftmac"
 var ss = await StateStore()  // just create new one to reset
 let speaker = AVSpeechSynthesizer()
@@ -325,7 +325,7 @@ func instantLetter(_ p: String) async {
   let oldPreDelay = await ss.preDelay
   if isFirstLetterCapital(p) {
     if await ss.allCapsBeep {
-      await doTone("500 50")
+      await doTone("800 50")
     } else {
       await ss.setPitchMultiplier(1.5)
     }
@@ -564,7 +564,7 @@ func ttsAllCapsBeep(_ p: String) async {
 }
 
 // MainActor because this is explicitly to be atomic
-@MainActor func instantTtsSyncState(_ p: String) async {
+func instantTtsSyncState(_ p: String) async {
   debugLogger.log("Enter: processAndQueueSync")
   let ps = p.split(separator: " ")
   if ps.count == 4 {
@@ -619,7 +619,7 @@ private func decodeIfNeeded(_ url: URL) async throws -> URL? {
   if url.pathExtension.lowercased() == "ogg" {
     debugLogger.log("Decoding OGG file at URL: \(url)")
     let decoder = OGGDecoder()
-    return try await withCheckedContinuation { continuation in
+    return await withCheckedContinuation { continuation in
       decoder.decode(url) { decodedUrl in
         continuation.resume(returning: decodedUrl)
       }


### PR DESCRIPTION
These changes only exist under swiftmac, no changes to other files in emacspeak in this set.

Some minor tweaks:
- Package.resolved added to .gitigonre
- Forked and use fork of OggDecode to make it warning free
- Caps sound now 800 50 to make it sound more unique from other tones
- ttsSyncState moved off the main actor