### PR TITLE
voice-setup.el: only match on mac at end of word

### DIFF
--- a/lisp/voice-setup.el
+++ b/lisp/voice-setup.el
@@ -130,7 +130,7 @@
    ((string-match "swiftmac" dtk-program)
     (require 'swiftmac-voices)
     (swiftmac-configure-tts))
-   ((string-match "mac" dtk-program)
+   ((string-match "mac\\'" dtk-program)
     (require 'mac-voices)
     (mac-configure-tts))
    ((string-match "espeak\\'" dtk-program)


### PR DESCRIPTION
This fixes problems when the path of DTK_PROGRAM contains the subword `mac`, for example in `emacspeak` or `emacs` . I ran into that problem on a NixOS system where espeak is part of the emacspeak package. 

In `voice-setup` the prior match for `mac-voices` was executed instead of `espeak-voices`. This lead to strange behaviour of the voice server. It kept pronouncing braces and parentheses instead of the actual text.