### PR TITLE
change define-key from `C-cm` to `C-c m`

### DIFF
--- a/lisp/emacspeak-erc.el
+++ b/lisp/emacspeak-erc.el
@@ -293,7 +293,7 @@ set the current local value to the result.")
            (keymapp erc-mode-map))
   (define-key erc-mode-map
               (kbd "C-c ") 'emacspeak-erc-toggle-speak-all-participants)
-  (define-key erc-mode-map (kbd "C-cm")
+  (define-key erc-mode-map (kbd "C-c m")
               'emacspeak-erc-toggle-my-monitor)
   (define-key erc-mode-map (kbd "C-c C-m") 'emacspeak-erc-toggle-room-monitor)
   (define-key erc-mode-map (kbd "C-c C-a")


### PR DESCRIPTION
The `kbd` code for 'emacspeak-erc-toggle-my-monitor had a typo: `C-cm` should be `C-c m`. I guess it shouldn't be `C-c C-m` since this key combination is defined for something else in the same file.